### PR TITLE
Refactor data provider

### DIFF
--- a/tests/HttpStatusInRangeTest.php
+++ b/tests/HttpStatusInRangeTest.php
@@ -36,10 +36,12 @@ class HttpStatusInRangeTest extends TestCase
 
     public function statusInRange()
     {
-        yield [HTTP_INFORMATIONAL, [100, 101, 199], [200, 99]];
-        yield [HTTP_SUCCESS, [200, 204, 299], [199, 300]];
-        yield [HTTP_REDIRECTION, [300, 301, 302, 399], [299, 400]];
-        yield [HTTP_CLIENT_ERROR, [400, 401, 403, 499], [399, 500]];
-        yield [HTTP_SERVER_ERROR, [500, 501, 504, 599], [499, 600]];
+        return [
+            [HTTP_INFORMATIONAL, [100, 101, 199], [200, 99]],
+            [HTTP_SUCCESS, [200, 204, 299], [199, 300]],
+            [HTTP_REDIRECTION, [300, 301, 302, 399], [299, 400]],
+            [HTTP_CLIENT_ERROR, [400, 401, 403, 499], [399, 500]],
+            [HTTP_SERVER_ERROR, [500, 501, 504, 599], [499, 600]],
+        ];
     }
 }


### PR DESCRIPTION
As title, use the items of array instead of using the ```yield``` for every item.
The more details are in the [PHPUnit doc](https://phpunit.de/manual/6.5/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers).